### PR TITLE
localhost causing nil exception.

### DIFF
--- a/lib/unobtrusive_flash.rb
+++ b/lib/unobtrusive_flash.rb
@@ -12,7 +12,7 @@ module UnobtrusiveFlash
       end
 
       cookie_flash += flash.to_a
-      cookies['flash'] = {:value => cookie_flash.to_json, :domain => ".#{request.host.split('.')[-2,2].join('.')}"}
+      cookies['flash'] = {:value => cookie_flash.to_json, :domain => '.' << request.domain}
       flash.discard
     end
   end


### PR DESCRIPTION
When using http://localhost/, nil exception will be thrown.
This is because its unusual TLD length cause exception when finding domain.
Use Rails build-in method for finding domain. It will be more accurate since it uses the `tld_length` setting in Rails.
