### PR TITLE
Fix hidden in boostrap bug

### DIFF
--- a/lib/generators/templates/unobtrusive_flash.js
+++ b/lib/generators/templates/unobtrusive_flash.js
@@ -12,7 +12,7 @@ $(function() {
   
     options = $.extend({type: 'notice', timeout: 5000}, options);
 
-    var $flash = $('<div class="flash-message flash-'+options.type+' invisible"><div class="message">'+message+'</div></div>');
+    var $flash = $('<div class="flash-message flash-'+options.type+'"><div class="message">'+message+'</div></div>');
 
     $('#flash-messages').prepend($flash);
     $flash.hide().delay(300).slideDown(100);


### PR DESCRIPTION
Fix #2 message always hidden in Twitter Bootstrap bug. Remove the unused 'invisible' class that is applied to message div which is always hidden by Bootstrap.
