### PR TITLE
NukeCookie doesn't work with port numbers in host

### DIFF
--- a/lib/assets/javascripts/unobtrusive_flash.js
+++ b/lib/assets/javascripts/unobtrusive_flash.js
@@ -6,7 +6,7 @@ $(function() {
       yesterday.setDate(yesterday.getDate() - 1);
       var hostParts = window.location.host.split('.').reverse();
       var expireHost = hostParts.shift();
-      expireHost = expireHost.replace(/^([a-z]{1,})\:[0-9]{1,5}/, '$1')
+      expireHost = expireHost.replace(/^([a-z]{1,})\:[0-9]{1,5}/, '$1');
       $.each(hostParts, function(i,part) {
         expireHost = part + '.' + expireHost;
         document.cookie = cookieName+'=; path=/;expires='+yesterday+'; domain='+expireHost;


### PR DESCRIPTION
I had a problem where my cookies wasn't deleted after displaying flash message, resulting in displaying same flash message on each page reload, until it was overwritten with new one.
I found the problem was port number in expireHost variable (it happened on my localhost). Added some line to remove it, now works fine for me.
