### PR TITLE
Map remaining Rails flash messages to bootstrap styles

### DIFF
--- a/lib/assets/javascripts/unobtrusive_flash_bootstrap.js
+++ b/lib/assets/javascripts/unobtrusive_flash_bootstrap.js
@@ -10,7 +10,13 @@ $(function() {
     options = $.extend({type: 'notice', timeout: 5000}, options);
 
     // Workaround for common Rails flash type to match common Bootstrap alert type
-    if (options.type=='notice') options.type = 'info';
+    if (options.type=='notice') {
+      options.type = 'info';
+    } else if(options.type=='alert') {
+      options.type = 'warning';
+    } else if(options.type=='error') {
+      options.type = 'danger';
+    }
 
     var $flash = $('<div class="alert alert-'+options.type+'"><button type="button" class="close" data-dismiss="alert">&times;</button>'+message+'</div>');
 


### PR DESCRIPTION
Similar to #9 but this seems to map a little closer to what Rails uses for it's default set of flash messages.
