### PR TITLE
Use `hostname` when nuking cookies

### DIFF
--- a/lib/assets/javascripts/unobtrusive_flash.js
+++ b/lib/assets/javascripts/unobtrusive_flash.js
@@ -4,7 +4,7 @@ $(function() {
   function nukeCookie(cookieName) {
       var yesterday = new Date();
       yesterday.setDate(yesterday.getDate() - 1);
-      var hostParts = window.location.host.split('.').reverse();
+      var hostParts = window.location.hostname.split('.').reverse();
       var expireHost = hostParts.shift();
       expireHost = expireHost.replace(/^([a-z]{1,})\:[0-9]{1,5}/, '$1');
       $.each(hostParts, function(i,part) {


### PR DESCRIPTION
Unlike `hostname`, `host` contains the port as well, and therefore it
won't clear cookies set to eg. `localhost`, when the app is actually
running on `localhost:3000`.
