### PR TITLE
Check $flashContainer dynamically

### DIFF
--- a/lib/assets/javascripts/unobtrusive_flash_bootstrap.js
+++ b/lib/assets/javascripts/unobtrusive_flash_bootstrap.js
@@ -4,8 +4,6 @@
 // Declare a .unobtrusive-flash-container wherever you want the messages to appear
 // Defaults to .container, .container-fluid (core Bootstrap classes), or just the body tag, whichever is present
 $(function() {
-  var $flashContainer = $($('.unobtrusive-flash-container')[0] || $('.container')[0] || $('.container-fluid')[0] || $('body')[0]);
-
   UnobtrusiveFlash.showFlashMessage = function(message, options) {
     options = $.extend({type: 'notice', timeout: 0}, options);
 
@@ -20,6 +18,7 @@ $(function() {
 
     var $flash = $('<div class="alert alert-'+options.type+'"><button type="button" class="close" data-dismiss="alert">&times;</button>'+message+'</div>');
 
+    var $flashContainer = $($('.unobtrusive-flash-container')[0] || $('.container')[0] || $('.container-fluid')[0] || $('body')[0]);
     $flashContainer.prepend($flash);
 
     $flash.hide().delay(300).slideDown(100);


### PR DESCRIPTION
I guess unobtrusive_flash should check flash container dynamically and in “runtime” and not just once(on document.ready event).

For example: this could be useful when you want to display flash message in modal window(containing .unobtrusive-flash-container div) that is added to the DOM after page is loaded and rendered.
