### PR TITLE
Consider only visible .unobtrusive-flash-container-s

### DIFF
--- a/lib/assets/javascripts/unobtrusive_flash_bootstrap.js
+++ b/lib/assets/javascripts/unobtrusive_flash_bootstrap.js
@@ -22,7 +22,7 @@ window.UnobtrusiveFlash.flashOptions = {type: 'notice', timeout: 0};
 
     var $flash = $('<div class="alert alert-'+options.type+' fade in"><button type="button" class="close" data-dismiss="alert">&times;</button>'+message+'</div>');
 
-    var $flashContainer = $($('.unobtrusive-flash-container')[0] || $('.container')[0] || $('.container-fluid')[0] || $('body')[0]);
+    var $flashContainer = $($('.unobtrusive-flash-container:visible')[0] || $('.container:visible')[0] || $('.container-fluid:visible')[0] || $('body')[0]);
     $flashContainer.prepend($flash);
 
     $flash.hide().delay(300).slideDown(100);


### PR DESCRIPTION
There could be hidden `.unobtrusive-flash-container`s in DOM(i.e. hidden embedded modal window widget) and there isn't much sense in displaying flash messages that are visible. With this fix in the case explained earlier, flash message would be displayed in some other visible container: `.container`, `.container-fluid`, `body`.
