### PR TITLE
Clear flash before showing next flash.

### DIFF
--- a/lib/assets/javascripts/unobtrusive_flash.js
+++ b/lib/assets/javascripts/unobtrusive_flash.js
@@ -17,7 +17,7 @@ window.UnobtrusiveFlash = {};
 
   // Extracts flash array stored in cookie and clears the cookie
   function extractFlashFromCookies() {
-    var data = null;
+    var flashMessages = [];
     if (document.cookie && document.cookie !== '') {
       var cookies = document.cookie.split(';');
       var name = 'flash';
@@ -33,22 +33,21 @@ window.UnobtrusiveFlash = {};
       }
 
       try {
-        data = $.parseJSON(cookieValue);
+        flashMessages = $.parseJSON(cookieValue);
       } catch(e) {
       }
 
       nukeCookie('flash');
     }
 
-    return data;
+    return flashMessages;
   }
 
   window.UnobtrusiveFlash.showFlash = function(flashMessages) {
-    if (flashMessages !== null) {
-      $.each(flashMessages, function(_, flashMessage) {
-        $(window).trigger('rails:flash', {type: flashMessage[0], message: flashMessage[1]});
-      });
-    }
+    $(window).trigger('rails:flash', {command: "clear flash"});
+    $.each(flashMessages, function(_, flashMessage) {
+      $(window).trigger('rails:flash', {type: flashMessage[0], message: flashMessage[1]});
+    });
   };
 
   // Reads flash messages from cookies and fires corresponding events

--- a/lib/assets/javascripts/unobtrusive_flash_bootstrap.js
+++ b/lib/assets/javascripts/unobtrusive_flash_bootstrap.js
@@ -46,7 +46,7 @@ window.UnobtrusiveFlash.flashOptions = {type: 'notice',
   };
 
   function clearFlash() {
-    flashContainer().empty();
+    flashContainer().children("div.alert").remove();
   };
 
   UnobtrusiveFlash.executeCommand = function(commandName) {

--- a/lib/assets/javascripts/unobtrusive_flash_bootstrap.js
+++ b/lib/assets/javascripts/unobtrusive_flash_bootstrap.js
@@ -26,7 +26,7 @@ window.UnobtrusiveFlash.flashOptions = {type: 'notice',
       options.type = 'danger';
     }
 
-    var $flash = $('<div class="alert alert-'+options.type+' fade in"><button type="button" class="close" data-dismiss="alert">&times;</button>'+message+'</div>');
+    var $flash = $('<div class="alert alert-'+options.type+' fade in unobtrusive-flash-message"><button type="button" class="close" data-dismiss="alert">&times;</button>'+message+'</div>');
 
     flashContainer().prepend($flash);
 
@@ -46,7 +46,7 @@ window.UnobtrusiveFlash.flashOptions = {type: 'notice',
   };
 
   function clearFlash() {
-    flashContainer().children("div.alert").remove();
+    flashContainer().children('div.unobtrusive-flash-message').remove();
   };
 
   UnobtrusiveFlash.executeCommand = function(commandName) {

--- a/lib/assets/javascripts/unobtrusive_flash_bootstrap.js
+++ b/lib/assets/javascripts/unobtrusive_flash_bootstrap.js
@@ -4,9 +4,15 @@
 // Declare a .unobtrusive-flash-container wherever you want the messages to appear
 // Defaults to .container, .container-fluid (core Bootstrap classes), or just the body tag, whichever is present
 
-window.UnobtrusiveFlash.flashOptions = {type: 'notice', timeout: 0};
+window.UnobtrusiveFlash.flashOptions = {type: 'notice',
+                                        timeout: 0,
+                                        clearFlashOnNextRequest: false};
 
 (function() {
+
+  function flashContainer() {
+    return $($('.unobtrusive-flash-container')[0] || $('.container')[0] || $('.container-fluid')[0] || $('body')[0]);
+  };
 
   UnobtrusiveFlash.showFlashMessage = function(message, options) {
     options = $.extend(UnobtrusiveFlash.flashOptions, options);
@@ -22,8 +28,7 @@ window.UnobtrusiveFlash.flashOptions = {type: 'notice', timeout: 0};
 
     var $flash = $('<div class="alert alert-'+options.type+' fade in"><button type="button" class="close" data-dismiss="alert">&times;</button>'+message+'</div>');
 
-    var $flashContainer = $($('.unobtrusive-flash-container')[0] || $('.container')[0] || $('.container-fluid')[0] || $('body')[0]);
-    $flashContainer.prepend($flash);
+    flashContainer().prepend($flash);
 
     $flash.hide().delay(300).slideDown(100);
 
@@ -36,8 +41,30 @@ window.UnobtrusiveFlash.flashOptions = {type: 'notice', timeout: 0};
     }
   };
 
-  var flashHandler = function(e, params) {
-    UnobtrusiveFlash.showFlashMessage(params.message, {type: params.type});
+  function isCommand(params) {
+    return typeof params.command !== "undefined";
+  };
+
+  function clearFlash() {
+    flashContainer().empty();
+  };
+
+  UnobtrusiveFlash.executeCommand = function(commandName) {
+    switch (commandName) {
+      case "clear flash":
+        if (UnobtrusiveFlash.flashOptions.clearFlashOnNextRequest) {
+          clearFlash();
+        }
+        break;
+    }
+  }
+
+  flashHandler = function(e, params) {
+    if (isCommand(params)) {
+      UnobtrusiveFlash.executeCommand(params.command);
+    } else {
+      UnobtrusiveFlash.showFlashMessage(params.message, {type: params.type});
+    }
   };
 
   $(window).bind('rails:flash', flashHandler);

--- a/lib/assets/javascripts/unobtrusive_flash_ui.js
+++ b/lib/assets/javascripts/unobtrusive_flash_ui.js
@@ -45,7 +45,7 @@ window.UnobtrusiveFlash.flashOptions = {type: 'notice',
   };
 
   function clearFlash() {
-    flashContainer().empty();
+    flashContainer().children('div.unobtrusive-flash-message-wrapper').remove();
   };
 
   UnobtrusiveFlash.executeCommand = function(commandName) {

--- a/lib/assets/javascripts/unobtrusive_flash_ui.js
+++ b/lib/assets/javascripts/unobtrusive_flash_ui.js
@@ -2,9 +2,11 @@
 // Remember to link unobtrusive_flash_ui.css as well
 //
 // Shows flash messages as translucent bars on top of the page
-window.UnobtrusiveFlash.flashOptions = {type: 'notice', timeout: 0};
+window.UnobtrusiveFlash.flashOptions = {type: 'notice',
+                                        timeout: 0,
+                                        clearFlashOnNextRequest: false};
 
-(function(){
+(function() {
 
   function hideFlash($flash) {
     $flash.slideUp(100,function(){
@@ -12,11 +14,15 @@ window.UnobtrusiveFlash.flashOptions = {type: 'notice', timeout: 0};
     });
   }
 
+  function flashContainer() {
+    return $('#unobtrusive-flash-messages');
+  };
+
   UnobtrusiveFlash.showFlashMessage = function(message, options) {
     options = $.extend(UnobtrusiveFlash.flashOptions, options);
 
     var $flash = $('<div class="unobtrusive-flash-message-wrapper unobtrusive-flash-'+options.type+'"><div class="unobtrusive-flash-message">'+message+'</div></div>');
-    var $flashContainer  = $('#unobtrusive-flash-messages');
+    var $flashContainer  = flashContainer();
     if ($flashContainer.length==0) {
       $flashContainer = $('<div/>').attr('id', 'unobtrusive-flash-messages').prependTo('body');
     }
@@ -34,8 +40,30 @@ window.UnobtrusiveFlash.flashOptions = {type: 'notice', timeout: 0};
     }
   };
 
+  function isCommand(params) {
+    return typeof params.command !== "undefined";
+  };
+
+  function clearFlash() {
+    flashContainer().empty();
+  };
+
+  UnobtrusiveFlash.executeCommand = function(commandName) {
+    switch (commandName) {
+      case "clear flash":
+        if (UnobtrusiveFlash.flashOptions.clearFlashOnNextRequest) {
+          clearFlash();
+        }
+        break;
+    }
+  }
+
   flashHandler = function(e, params) {
-    UnobtrusiveFlash.showFlashMessage(params.message, {type: params.type});
+    if (isCommand(params)) {
+      UnobtrusiveFlash.executeCommand(params.command);
+    } else {
+      UnobtrusiveFlash.showFlashMessage(params.message, {type: params.type});
+    }
   };
 
   $(window).bind('rails:flash', flashHandler);

--- a/spec/integration/api_spec.rb
+++ b/spec/integration/api_spec.rb
@@ -4,7 +4,8 @@ describe "api spec", type: :feature, js: true do
   it 'should invoke the API for each flash message' do
     visit '/test/api'
     expect(page).to have_content 'Page loaded'
-    expect(evaluate_script('window.flashMessages')).to eq [
+    expect(evaluate_script('window.flashMessages')
+          .select { |flash| flash['message'] }).to eq [
       {'type' => 'notice', 'message' => 'Inline Notice'},
       {'type' => 'error', 'message' => 'Ajax Error'}
     ]

--- a/spec/integration/bootstrap_spec.rb
+++ b/spec/integration/bootstrap_spec.rb
@@ -20,4 +20,19 @@ describe "bootstrap spec", type: :feature, js: true do
     find('.alert.alert-info .close').click
     expect(page).to have_no_content 'Inline Notice'
   end
+
+  it 'should append new messages to existing messages when the JS option clearFlashOnNextRequest is set to false (which is the default)' do
+    visit '/test/bootstrap'
+    expect(page).to have_content 'Ajax Error', count: 1
+    page.execute_script("$.get('/test/ajax_flash');")
+    expect(page).to have_content 'Ajax Error', count: 2
+  end
+
+  it 'should clear existing messages before displaying new messages when the JS option clearFlashOnNextRequest is set to true' do
+    visit '/test/bootstrap'
+    page.execute_script('UnobtrusiveFlash.flashOptions.clearFlashOnNextRequest = true;')
+    expect(page).to have_content 'Ajax Error', count: 1
+    page.execute_script("$.get('/test/ajax_flash');")
+    expect(page).to have_content 'Ajax Error', count: 1
+  end
 end

--- a/spec/integration/bootstrap_spec.rb
+++ b/spec/integration/bootstrap_spec.rb
@@ -43,10 +43,17 @@ describe "bootstrap spec", type: :feature, js: true do
     non_message_content = "not a message"
     non_message_element = "<p id=\"#{non_message_id}\">#{non_message_content}</p>"
 
+    non_message_alert_id = "non-message-alert-element"
+    non_message_alert_content = "this .alert element is not an unobtrusive flash message"
+    non_message_alert_element = "<div id=\"#{non_message_alert_id}\">#{non_message_alert_content}</div>"
+
     page.execute_script('UnobtrusiveFlash.flashOptions.clearFlashOnNextRequest = true;')
     page.execute_script("$('.alert').parent().prepend('#{non_message_element}');")
+    page.execute_script("$('.alert').parent().prepend('#{non_message_alert_element}');")
     expect(find("##{non_message_id}")).to have_content non_message_content, count: 1
+    expect(find("##{non_message_alert_id}")).to have_content non_message_alert_content, count: 1
     page.execute_script("$.get('/test/ajax_flash');")
     expect(find("##{non_message_id}")).to have_content non_message_content, count: 1
+    expect(find("##{non_message_alert_id}")).to have_content non_message_alert_content, count: 1
   end
 end

--- a/spec/integration/bootstrap_spec.rb
+++ b/spec/integration/bootstrap_spec.rb
@@ -35,4 +35,18 @@ describe "bootstrap spec", type: :feature, js: true do
     page.execute_script("$.get('/test/ajax_flash');")
     expect(page).to have_content 'Ajax Error', count: 1
   end
+
+  specify 'clearing existing messages should only clear messages (and not other content) from the flash container' do
+    visit '/test/bootstrap'
+
+    non_message_id = "not-a-message"
+    non_message_content = "not a message"
+    non_message_element = "<p id=\"#{non_message_id}\">#{non_message_content}</p>"
+
+    page.execute_script('UnobtrusiveFlash.flashOptions.clearFlashOnNextRequest = true;')
+    page.execute_script("$('.alert').parent().prepend('#{non_message_element}');")
+    expect(find("##{non_message_id}")).to have_content non_message_content, count: 1
+    page.execute_script("$.get('/test/ajax_flash');")
+    expect(find("##{non_message_id}")).to have_content non_message_content, count: 1
+  end
 end

--- a/spec/integration/turbolinks_spec.rb
+++ b/spec/integration/turbolinks_spec.rb
@@ -6,7 +6,8 @@ if Rails.version =~ /^4\./ and Capybara.javascript_driver == :selenium
       visit '/test/turbolinks'
       click_link 'This is a turbolink'
       expect(page).to have_content 'Turbolink content'
-      expect(evaluate_script('window.flashMessages')).to eq [
+      expect(evaluate_script('window.flashMessages')
+            .select { |flash| flash['message'] }).to eq [
         {'type' => 'notice', 'message' => 'Inline Notice'},
         {'type' => 'notice', 'message' => 'Turbolink Notice'}
       ]

--- a/spec/integration/ui_spec.rb
+++ b/spec/integration/ui_spec.rb
@@ -7,4 +7,19 @@ describe "ui spec", type: :feature, js: true do
     expect(page).to have_content 'Inline Notice', count: 1
     expect(page).to have_content 'Ajax Error', count: 1
   end
+
+  it 'should append new messages to existing messages when the JS option clearFlashOnNextRequest is set to false (which is the default)' do
+    visit '/test/ui'
+    expect(page).to have_content 'Ajax Error', count: 1
+    page.execute_script("$.get('/test/ajax_flash');")
+    expect(page).to have_content 'Ajax Error', count: 2
+  end
+
+  it 'should clear existing messages before displaying new messages when the JS option clearFlashOnNextRequest is set to true' do
+    visit '/test/ui'
+    page.execute_script('UnobtrusiveFlash.flashOptions.clearFlashOnNextRequest = true;')
+    expect(page).to have_content 'Ajax Error', count: 1
+    page.execute_script("$.get('/test/ajax_flash');")
+    expect(page).to have_content 'Ajax Error', count: 1
+  end
 end

--- a/spec/integration/ui_spec.rb
+++ b/spec/integration/ui_spec.rb
@@ -22,4 +22,19 @@ describe "ui spec", type: :feature, js: true do
     page.execute_script("$.get('/test/ajax_flash');")
     expect(page).to have_content 'Ajax Error', count: 1
   end
+
+  specify 'clearing existing messages should only clear messages (and not other content) from the flash container' do
+    visit '/test/ui'
+
+    flash_container_id = "unobtrusive-flash-messages"
+    non_message_id = "not-a-message"
+    non_message_content = "not a message"
+    non_message_element = "<p id=\"#{non_message_id}\">#{non_message_content}</p>"
+
+    page.execute_script('UnobtrusiveFlash.flashOptions.clearFlashOnNextRequest = true;')
+    page.execute_script("$('##{flash_container_id}').prepend('#{non_message_element}');")
+    expect(find("##{non_message_id}")).to have_content non_message_content, count: 1
+    page.execute_script("$.get('/test/ajax_flash');")
+    expect(find("##{non_message_id}")).to have_content non_message_content, count: 1
+  end
 end


### PR DESCRIPTION
Hi! I'm not sure of the proper procedure for submitting pull requests so I'm sorry if I should have contacted you beforehand :) Anyway, I ran into the following issue and made the change in this commit to solve it. (I'm using the bootstrap version but I made parallel changes to the non-bootstrap version as well.)

The flash was not being cleared when ajax links were clicked:
-   If the link resulted in no flash, then the existing flash persisted.
-   If the link resulted in a flash, then it was prepended into the flash container, resulting in two flashes.

Since the idea of the flash is to display a message in response to one user action and then disappear,
-   If there is no flash to display, then I clear any existing flash.
-   If there is a flash to display, then I clear any existing flash and display the new flash.

Let me know if you'd like me to make any changes to this patch.

Note: Is this related to the following?
-   https://github.com/leonid-shevtsov/unobtrusive_flash/issues/23
-   https://github.com/leonid-shevtsov/unobtrusive_flash/issues/18
