### PR TITLE
Use request.host for apps hosted behind AWS ELB

### DIFF
--- a/lib/unobtrusive_flash/controller_mixin.rb
+++ b/lib/unobtrusive_flash/controller_mixin.rb
@@ -20,9 +20,15 @@ module UnobtrusiveFlash
 
     # Setting cookies for :all domains is broken for Heroku apps, read this article for details
     # https://devcenter.heroku.com/articles/cookies-and-herokuapp-com
+    #
+    # Setting cookies for :all domains also appears to be broken for apps hosted on EC2 behind
+    # AWS ELB. No written documentation on that yet, only quantitive analysis based on
+    # obvservation of a few instances of load balancers and EC2 instances accessed directly
+    # via their IP addresses.
+    #
     # You can also override this method in your controller if you need to customize the cookie domain
     def unobtrusive_flash_domain
-      if request.host =~ /\.herokuapp\.com$/
+      if request.host =~ /\.herokuapp\.com$/ || request.host =~ /\.amazonaws\.com$/
         request.host
       else
         :all

--- a/spec/domain_spec.rb
+++ b/spec/domain_spec.rb
@@ -21,5 +21,13 @@ describe UnobtrusiveFlash::ControllerMixin do
         expect(subject.send(:unobtrusive_flash_domain)).to eq('myapp.herokuapp.com')
       end
     end
+
+    context 'on AWS ELB' do
+      let(:host) { 'myapp-1989.eu-west-1.elb.amazonaws.com' }
+
+      it 'should use the host' do
+        expect(subject.send(:unobtrusive_flash_domain)).to eq('myapp-1989.eu-west-1.elb.amazonaws.com')
+      end
+    end
   end
 end


### PR DESCRIPTION
I recently inherited a legacy application which uses `unobtrusive_flash` and one of the first tasks I was given was to host it on AWS. It's generally a good practice to not expose your EC2 instances publicly, so I decided to use AWS ELB (service which provides you with load balancers). And everything worked except the component which relied on `unobtrusive_flash`!

The app is available under similarly looking URL: `myapp-1989.eu-west-1.elb.amazonaws.com` as well as behind some domain (CNAME pointing to load balancer's address). I traced back the AJAX requests while accessing the app in both ways and I noticed that cookies are restricted to `.amazonaws.com` domain and the cookie extraction function didn't see any `flash` cookie.

The observations are based on a quantitive analysis of a few different instances of AWS ELB and EC2 instances accessed directly via their IP addresses where the problem doesn't occur.

Let me know what you think!