### PR TITLE
Remove whitelisting for flash keys

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -101,18 +101,6 @@ UnobtrusiveFlash.showFlashMessage("Hello World", { type: "notice" });
 UnobtrusiveFlash.showFlashMessage("Error", { type: "error", timeout: 0 });
 ```
 
-## Using custom flash keys
-
-By default, Unobtrusive Flash only displays a limited set of flash types [(see UnobtrusiveFlash::ControllerMixin#unobtrusive_flash_keys)](https://github.com/leonid-shevtsov/unobtrusive_flash/blob/master/lib/unobtrusive_flash/controller_mixin.rb#L36). This is because some libraries use `flash` to keep data that is not directed at the user; for example, [Devise](https://github.com/plataformatec/devise) uses a boolean `flash[:timedout]`. If you use other keys to store messages, override `unobtrusive_flash_keys` in your controller:
-
-```ruby
-class ApplicationController
-  def unobtrusive_flash_keys
-    super << :success
-  end
-end
-```
-
 ## Issue with certain "hosted domains"
 
 There are [certain domains](https://publicsuffix.org/list/) that are considered "public" or "hosting" and specifically don't share cookies across subdomains. An example is `herokuapp.com` - a cookie set for `yourapp.herokuapp.com` will not be applied for `myapp.herokuapp.com`. This breaks the logic of `unobtrusive_flash` which is tuned for regular domains that could have internal subdomains.

--- a/lib/unobtrusive_flash/controller_mixin.rb
+++ b/lib/unobtrusive_flash/controller_mixin.rb
@@ -8,7 +8,7 @@ module UnobtrusiveFlash
       return unless flash.any?
       # TODO: replace configuration based on overriding methods with a conventional config block
       cookies[:flash] = {
-        value: UnobtrusiveFlash::ControllerMixin.append_flash_to_cookie(cookies[:flash], flash, unobtrusive_flash_keys),
+        value: UnobtrusiveFlash::ControllerMixin.append_flash_to_cookie(cookies[:flash], flash),
         domain: unobtrusive_flash_domain
       }
       flash.discard
@@ -31,27 +31,19 @@ module UnobtrusiveFlash
       end
     end
 
-    # List of all flash keys that will be displayed on the frontend. Override
-    # this method if you use more flash types.
-    def unobtrusive_flash_keys
-      [:notice, :alert, :error, :success, :warning]
-    end
-
     class << self
       # Prepares a safe and clean version of the flash hash for the frontend
       # flash - value of `flash` controller attribute
-      # displayable_flash_keys - list of flash keys that will be displayed
-      def sanitize_flash(flash, displayable_flash_keys)
-        displayable_flash = flash.select { |key, value| displayable_flash_keys.include?(key.to_sym) }
-        displayable_flash.map do |key, value|
+      def sanitize_flash(flash)
+        flash.map do |key, value|
           html_safe_value = value.html_safe? ? value : ERB::Util.html_escape(value)
           [key.to_s, html_safe_value]
         end
       end
 
-      def append_flash_to_cookie(existing_cookie, flash, unobtrusive_flash_keys)
+      def append_flash_to_cookie(existing_cookie, flash)
         cookie_flash = (existing_cookie && parse_cookie(existing_cookie)) || []
-        cookie_flash += sanitize_flash(flash, unobtrusive_flash_keys)
+        cookie_flash += sanitize_flash(flash)
         cookie_flash.uniq.to_json
       end
 

--- a/spec/sanitize_flash_spec.rb
+++ b/spec/sanitize_flash_spec.rb
@@ -3,33 +3,33 @@ require 'spec_helper'
 describe UnobtrusiveFlash::ControllerMixin do
   describe '.sanitize_flash' do
     it 'should escape messages that are not html safe' do
-      expect(described_class.sanitize_flash({:notice => '<bar>'}, [:notice])).to eq([["notice", '&lt;bar&gt;']])
+      expect(described_class.sanitize_flash({:notice => '<bar>'})).to eq([["notice", '&lt;bar&gt;']])
     end
 
     it 'should not escape messages that are html safe' do
-      expect(described_class.sanitize_flash({:notice => '<bar>'.html_safe}, [:notice])).to eq([["notice", '<bar>']])
+      expect(described_class.sanitize_flash({:notice => '<bar>'.html_safe})).to eq([["notice", '<bar>']])
     end
 
-    it 'should remove messages that are not whitelisted to be displayed' do
-      expect(described_class.sanitize_flash({:timedout => true}, [:notice])).to eq([])
+    it 'should allow custom flash keys' do
+      expect(described_class.sanitize_flash({'some.custom.key'.to_sym => "bar"})).to eq([["some.custom.key", "bar"]])
     end
   end
 
   describe '.append_flash_to_cookie' do
     it 'should create a cookie if there is none' do
-      expect(described_class.append_flash_to_cookie(nil, {:baz => 'qux'}, [:baz])).to eq('[["baz","qux"]]')
+      expect(described_class.append_flash_to_cookie(nil, {:baz => 'qux'})).to eq('[["baz","qux"]]')
     end
 
     it 'should reuse existing cookie' do
-      expect(described_class.append_flash_to_cookie('[["foo","bar"]]', {:baz => 'qux'}, [:baz])).to eq('[["foo","bar"],["baz","qux"]]')
+      expect(described_class.append_flash_to_cookie('[["foo","bar"]]', {:baz => 'qux'})).to eq('[["foo","bar"],["baz","qux"]]')
     end
 
     it 'should not insert flash is already in the cookie' do
-      expect(described_class.append_flash_to_cookie('[["foo","bar"]]', {:foo => 'bar'}, [:foo])).to eq('[["foo","bar"]]')
+      expect(described_class.append_flash_to_cookie('[["foo","bar"]]', {:foo => 'bar'})).to eq('[["foo","bar"]]')
     end
 
     it 'should reset cookie if it is null' do
-      expect(described_class.append_flash_to_cookie('null', {:foo => 'bar'}, [:foo])).to eq('[["foo","bar"]]')
+      expect(described_class.append_flash_to_cookie('null', {:foo => 'bar'})).to eq('[["foo","bar"]]')
     end
   end
 end


### PR DESCRIPTION
unobtrusive_flash makes assumptions about which flash keys are allowed by having this whitelist.
Which works great for default use cases - Twitter Bootstrap & regular Rails apps.

But since README mentions that user is allowed to implement his/her own UI handler(via rails:flash) I believe that this gem shouldn't limit user in key names. Especially since [Rails allows all kinds of keys](https://gist.githubusercontent.com/nfedyashev/ef8ca83e30a4b9ae4993e8a7f50e7b74/raw/d27ad116396a8524ff4dc69627d3e1153b81b679/rails%2520flash%2520keys.txt).

In which cases overriding `unobtrusive_flash_keys` is not enough?

In my rails app I'm using `unobtrusive_flash` not only for regular flash messages but for some custom notification-kind of messages. Think of it as glorified modal windows where we need to pass some data via flash key. In this case flash keys are dynamic(contains IDs) and could not be anticipatorily added to the white list.

[Potential CHANGELOG diff](https://gist.githubusercontent.com/nfedyashev/34ccc585bd9f2f6f4ad6613225039880/raw/29639409a9d0bf737a0c0aa74f5cee183b7099b4/changelog.diff)