### PR TITLE
Update deprecated method

### DIFF
--- a/lib/assets/javascripts/unobtrusive_flash.js
+++ b/lib/assets/javascripts/unobtrusive_flash.js
@@ -33,7 +33,7 @@ window.UnobtrusiveFlash = {};
       }
 
       try {
-        data = $.parseJSON(cookieValue);
+        data = JSON.parse(cookieValue);
       } catch(e) {
       }
 


### PR DESCRIPTION
$.parseJSON is deprecated as of jQuery 3 and JSON.parse works in all modern browsers.

See http://api.jquery.com/jquery.parsejson/ and https://caniuse.com/#feat=json